### PR TITLE
Fix: 개인별 스케쥴 기록 생성 로직에서 사용자가 보내준 타임 테이블로 덮어씌워주는 로직으로 변경

### DIFF
--- a/src/main/java/conference/clerker/domain/schedule/repository/TimeTableRepository.java
+++ b/src/main/java/conference/clerker/domain/schedule/repository/TimeTableRepository.java
@@ -1,7 +1,10 @@
 package conference.clerker.domain.schedule.repository;
 
+import conference.clerker.domain.schedule.schema.ScheduleTime;
 import conference.clerker.domain.schedule.schema.TimeTable;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TimeTableRepository extends JpaRepository<TimeTable, Long> {
+    void deleteAllByScheduleTime(ScheduleTime scheduleTime);
 }

--- a/src/main/java/conference/clerker/global/exception/ErrorCode.java
+++ b/src/main/java/conference/clerker/global/exception/ErrorCode.java
@@ -17,6 +17,9 @@ public enum ErrorCode {
     PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT-001", "프로젝트를 찾을 수 없습니다."),
 
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "SCHEDULE-001", "스케쥴을 찾을 수 없습니다."),
+
+    SCHEDULE_TIME_NOT_FOUND(HttpStatus.NOT_FOUND, "SCHEDULE_TIME-001", "스케쥴 시간표를 찾을 수 없습니다."),
+
     DUPLICATE_TIME(HttpStatus.CONFLICT, "SCHEDULE-002", "중복된 시간은 스케쥴에 등록할 수 없습니다."),
 
     MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "MEETING-001", "회의를 찾을 수 없습니다"),


### PR DESCRIPTION
# 기능 목록 구현

1. 스케쥴 참여 기록 생성 시 사용자가 입력한 타임 테이블을 그대로 덮어씌우는 기능 작성
2. ScheduleTimeRepository 메서드 추가