### PR TITLE
Develop

### DIFF
--- a/src/main/java/conference/clerker/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/conference/clerker/domain/meeting/controller/MeetingController.java
@@ -25,9 +25,6 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/meeting")
 public class MeetingController {
 
-    @Value("${baseUrl.front}")
-    private String frontUrl;
-
     private final MeetingService meetingService;
     private final OrganizationService organizationService;
     private final NotificationService notificationService;
@@ -63,10 +60,8 @@ public class MeetingController {
         Meeting meeting = meetingService.findById(meetingId);
 
         if (meeting.getIsEnded()) {
-            String redirectionUrl = frontUrl + "/project/summary/" + meetingId;
             return ResponseEntity.status(HttpStatus.FOUND)
-                    .location(URI.create(redirectionUrl))
-                    .build();
+                    .body(meetingService.redirectToMeetingDetailPage(meetingId));
         }
         return ResponseEntity.ok(meeting);
     }

--- a/src/main/java/conference/clerker/domain/meeting/dto/response/MeetingResultDTO.java
+++ b/src/main/java/conference/clerker/domain/meeting/dto/response/MeetingResultDTO.java
@@ -3,12 +3,11 @@ package conference.clerker.domain.meeting.dto.response;
 import conference.clerker.domain.meeting.schema.FileType;
 
 
-import java.util.List;
 import java.util.Map;
 
 public record MeetingResultDTO(
         Long meetingId,
         String name,
         String domain,
-        Map<FileType, List<MeetingFIleDTO>> files
+        Map<FileType, MeetingFIleDTO> files
 ) {}

--- a/src/main/java/conference/clerker/domain/meeting/service/MeetingService.java
+++ b/src/main/java/conference/clerker/domain/meeting/service/MeetingService.java
@@ -16,7 +16,9 @@ import conference.clerker.global.exception.CustomException;
 import conference.clerker.global.exception.ErrorCode;
 import conference.clerker.global.exception.domain.AuthException;
 import conference.clerker.global.exception.domain.MeetingException;
+import java.util.HashMap;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +30,9 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MeetingService {
+
+    @Value("${baseUrl.front}")
+    private String frontUrl;
 
     private final MeetingRepository meetingRepository;
     private final ProjectRepository projectRepository;
@@ -60,6 +65,15 @@ public class MeetingService {
     public Meeting findById(Long id) {
         return meetingRepository.findById(id)
                 .orElseThrow(() -> new MeetingException(ErrorCode.MEETING_NOT_FOUND));
+    }
+
+    public Map<String, String> redirectToMeetingDetailPage(Long meetingId) {
+        String redirectionUrl = frontUrl + "/project/summary/" + meetingId;
+
+        Map<String, String> body = new HashMap<>();
+        body.put("redirectUrl", redirectionUrl);
+
+        return body;
     }
 
     // 미팅 파일 목록 조회

--- a/src/main/java/conference/clerker/domain/meeting/service/MeetingService.java
+++ b/src/main/java/conference/clerker/domain/meeting/service/MeetingService.java
@@ -58,21 +58,21 @@ public class MeetingService {
     }
 
     public Meeting findById(Long id) {
-        return meetingRepository.findById(id).orElseThrow(() -> new MeetingException(ErrorCode.MEETING_NOT_FOUND));
+        return meetingRepository.findById(id)
+                .orElseThrow(() -> new MeetingException(ErrorCode.MEETING_NOT_FOUND));
     }
 
-    public MeetingResultDTO findByIdAndMeetingFileId(Long meetingId) {
+    // 미팅 파일 목록 조회
+    public MeetingResultDTO findMeetingFiles(Long meetingId) {
         Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new RuntimeException("Meeting not found id: " + meetingId));
 
         Map<FileType, List<MeetingFIleDTO>> filesByType = meetingFileRepository.findByMeetingId(meetingId).stream()
-                .filter(file -> file.getFileType() != FileType.IMAGE) // IMAGE 타입을 제외
+                .filter(file -> file.getFileType() != FileType.IMAGE)
                 .collect(Collectors.groupingBy(
                         MeetingFile::getFileType,
                         Collectors.mapping(MeetingFIleDTO::new, Collectors.toList())
                 ));
-
-
 
         return new MeetingResultDTO(
                 meeting.getId(),
@@ -82,6 +82,7 @@ public class MeetingService {
         );
     }
 
+    @Transactional
     public void setEnded(Long meetingId) {
         Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new MeetingException(ErrorCode.MEETING_NOT_FOUND));

--- a/src/main/java/conference/clerker/domain/meeting/service/MeetingService.java
+++ b/src/main/java/conference/clerker/domain/meeting/service/MeetingService.java
@@ -98,9 +98,10 @@ public class MeetingService {
     }
 
     @Transactional
-    public void setEnded(Long meetingId) {
+    public void endMeeting(Long meetingId, String domain) {
         Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new MeetingException(ErrorCode.MEETING_NOT_FOUND));
         meeting.setIsEnded(true);
+        meeting.setDomain(domain);
     }
 }

--- a/src/main/java/conference/clerker/domain/meeting/service/MeetingService.java
+++ b/src/main/java/conference/clerker/domain/meeting/service/MeetingService.java
@@ -81,11 +81,12 @@ public class MeetingService {
         Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new RuntimeException("Meeting not found id: " + meetingId));
 
-        Map<FileType, List<MeetingFIleDTO>> filesByType = meetingFileRepository.findByMeetingId(meetingId).stream()
+        Map<FileType, MeetingFIleDTO> filesByType = meetingFileRepository.findByMeetingId(meetingId).stream()
                 .filter(file -> file.getFileType() != FileType.IMAGE)
-                .collect(Collectors.groupingBy(
+                .collect(Collectors.toMap(
                         MeetingFile::getFileType,
-                        Collectors.mapping(MeetingFIleDTO::new, Collectors.toList())
+                        MeetingFIleDTO::new,
+                        (existing, replacement) -> replacement // 충돌 발생 시, 최신 파일로 대체
                 ));
 
         return new MeetingResultDTO(

--- a/src/main/java/conference/clerker/domain/meeting/service/MeetingService.java
+++ b/src/main/java/conference/clerker/domain/meeting/service/MeetingService.java
@@ -81,4 +81,10 @@ public class MeetingService {
                 filesByType
         );
     }
+
+    public void setEnded(Long meetingId) {
+        Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new MeetingException(ErrorCode.MEETING_NOT_FOUND));
+        meeting.setIsEnded(true);
+    }
 }

--- a/src/main/java/conference/clerker/domain/member/controller/AuthController.java
+++ b/src/main/java/conference/clerker/domain/member/controller/AuthController.java
@@ -30,10 +30,12 @@ public class AuthController {
             @Parameter(description = "프로필 사진", required = true, content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
             @RequestPart("profileImage") MultipartFile profileImage,
             @Parameter(description = "변경하려는 username", required = true)
-            @RequestPart("username") String username) {
-        authService.update(principal.getMember().getId(), profileImage, username);
-
-        return ResponseEntity.noContent().build();
+            @Valid @RequestPart("username") String username) {
+        String accessToken = authService.update(principal.getMember().getId(), profileImage, username);
+        if(accessToken == null) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.noContent().header("Authorization", "Bearer " + accessToken).build();
     }
 
 }

--- a/src/main/java/conference/clerker/domain/member/controller/AuthController.java
+++ b/src/main/java/conference/clerker/domain/member/controller/AuthController.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/conference/clerker/domain/member/service/AuthService.java
+++ b/src/main/java/conference/clerker/domain/member/service/AuthService.java
@@ -8,6 +8,9 @@ import conference.clerker.domain.member.schema.Profile;
 import conference.clerker.global.aws.s3.S3FileService;
 import conference.clerker.global.exception.ErrorCode;
 import conference.clerker.global.exception.domain.AuthException;
+import conference.clerker.global.jwt.JwtProvider;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,14 +26,20 @@ public class AuthService {
     private final ProfileRepository profileRepository;
     private final MemberRepository memberRepository;
     private final S3FileService s3FileService;
+    private final JwtProvider jwtProvider;
 
     @Transactional
-    public void update(Long memberId, MultipartFile profileImage, String username) {
+    public String update(Long memberId, MultipartFile profileImage, String username) {
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new AuthException(ErrorCode.MEMBER_NOT_FOUND));
 
         Profile existingProfile = profileRepository.findByMember(member).orElse(null);
 
-        member.setUsername(username);
+        String accessToken = null;
+
+        if(!member.getUsername().equals(username)) {
+            member.setUsername(username);
+            accessToken = generateToken(member);
+        }
 
         // 프로필 이미지가 업로드된 경우
         if (profileImage != null && !profileImage.isEmpty()) {
@@ -55,5 +64,13 @@ public class AuthService {
                 profileRepository.save(profile);
             }
         }
+        return accessToken;
+    }
+
+    private String generateToken(Member member) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("username", member.getUsername());
+        claims.put("email", member.getEmail());
+        return jwtProvider.generateToken(claims);
     }
 }

--- a/src/main/java/conference/clerker/domain/model/controller/ModelController.java
+++ b/src/main/java/conference/clerker/domain/model/controller/ModelController.java
@@ -43,15 +43,18 @@ public class ModelController {
 
     @PostMapping("/testProcessResponse")
     @Operation(
-            summary = "processModelResponse 메서드 테스트",
-            description = "테스트 데이터를 사용하여 processModelResponse 메서드를 실행합니다."
+            summary = "모델링 결과 이후의 로직 테스트",
+            description = "1. 받은 raw text + md file + image.zip 을 통해 zip 파일 압축 해제 후 image들을 각각 s3에 저장\n\n"
+                    + "2. md 파일에 해당 image S3 url 삽입\n\n"
+                    + "3. 클라이언트에게 md file + raw text 반환"
     )
     public ResponseEntity<String> testProcessResponse(
-            @RequestParam(name = "meetingId") Long meetingId, // 파라미터 이름 명시
+            @RequestParam("meetingId") Long meetingId, // 파라미터 이름 명시
+            @RequestParam("domain") String domain,
             @RequestBody ModelResponseDTO response
     ) {
         try {
-            modelService.testProcessModelResponse(response, meetingId);
+            modelService.testProcessModelResponse(response, meetingId, domain);
             return ResponseEntity.ok("processModelResponse 메서드가 성공적으로 실행되었습니다.");
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/conference/clerker/domain/model/dto/response/ModelResponseDTO.java
+++ b/src/main/java/conference/clerker/domain/model/dto/response/ModelResponseDTO.java
@@ -4,5 +4,5 @@ package conference.clerker.domain.model.dto.response;
 public record ModelResponseDTO(
         String report,
         String stt,
-        String images
+        String diagram_image
 ) {}

--- a/src/main/java/conference/clerker/domain/model/service/ModelService.java
+++ b/src/main/java/conference/clerker/domain/model/service/ModelService.java
@@ -56,7 +56,7 @@ public class ModelService {
                     .body(BodyInserters.fromValue(modelRequestDTO))
                     .retrieve()
                     .bodyToMono(ModelResponseDTO.class)
-                    .doOnNext(response -> processModelResponse(response, meetingId)) // 받은 ModelResponseDTO를 통한 로직 실행.
+                    .doOnNext(response -> processModelResponse(response, meetingId, domain)) // 받은 ModelResponseDTO를 통한 로직 실행.
                     .doFinally(signalType -> closeMp3File(mp3File, meetingId));
         } catch (IOException e) {
             log.error("파일 변환 중 IO 에러 발생: {}", e.getMessage());
@@ -69,15 +69,15 @@ public class ModelService {
 
     //테스트용
     @Transactional
-    public void testProcessModelResponse(ModelResponseDTO response, Long meetingId) {
-        meetingService.setEnded(meetingId);
-        processModelResponse(response, meetingId);
+    public void testProcessModelResponse(ModelResponseDTO response, Long meetingId, String domain) {
+        meetingService.endMeeting(meetingId, domain);
+        processModelResponse(response, meetingId, domain);
     }
 
     // 받은 ModelResponseDTO를 통한 로직 실행.
-    private void processModelResponse(ModelResponseDTO response, Long meetingId) {
+    private void processModelResponse(ModelResponseDTO response, Long meetingId, String domain) {
         // meeting 엔티티 컬럼 변경 (회의 종료)
-        meetingService.setEnded(meetingId);
+        meetingService.endMeeting(meetingId, domain);
 
         // 여기서 받은 url들을 토대로 파일을 s3에 저장한 뒤 DB에 버킷 경로 저장
         try {

--- a/src/main/java/conference/clerker/domain/model/service/ModelService.java
+++ b/src/main/java/conference/clerker/domain/model/service/ModelService.java
@@ -82,7 +82,7 @@ public class ModelService {
         // 여기서 받은 url들을 토대로 파일을 s3에 저장한 뒤 DB에 버킷 경로 저장
         try {
             // zip 파일 압축 해제 후 이미지 업로드
-            Map<String, String> imageUrlMap = s3FileService.transferZipContentFromOtherS3(modelServerBucketName, response.images(), "images", meetingId);
+            Map<String, String> imageUrlMap = s3FileService.transferZipContentFromOtherS3(modelServerBucketName, response.diagram_image(), "images", meetingId);
             // 업로드된 이미지의 파일명과 URL을 MeetingFile에 저장
             for (Map.Entry<String, String> entry : imageUrlMap.entrySet()) {
                 String fileName = entry.getKey();      // 이미지 파일명

--- a/src/main/java/conference/clerker/domain/model/service/ModelService.java
+++ b/src/main/java/conference/clerker/domain/model/service/ModelService.java
@@ -76,6 +76,9 @@ public class ModelService {
 
     // 받은 ModelResponseDTO를 통한 로직 실행.
     private void processModelResponse(ModelResponseDTO response, Long meetingId) {
+        // meeting 엔티티 컬럼 변경 (회의 종료)
+        meetingService.setEnded(meetingId);
+
         // 여기서 받은 url들을 토대로 파일을 s3에 저장한 뒤 DB에 버킷 경로 저장
         try {
             // zip 파일 압축 해제 후 이미지 업로드
@@ -221,9 +224,6 @@ public class ModelService {
 
     // s3 업로드 후 로컬 환경에 설치되는 mp3 파일 삭제
     private void closeMp3File(MultipartFile mp3File, Long meetingId) {
-
-        meetingService.setEnded(meetingId);
-
         try {
             if (mp3File != null) {
                 mp3File.getInputStream();

--- a/src/main/java/conference/clerker/global/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/conference/clerker/global/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
@@ -7,6 +7,7 @@ import conference.clerker.global.oauth2.service.OAuth2UserPrincipal;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -25,13 +26,16 @@ import java.util.Map;
 @Component
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
+    @Value("${baseUrl.front}")
+    private String frontUrl;
+
     private final JwtProvider jwtProvider;
 
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException {
-        String targetUrl = "http://localhost:3000/login/callback";
+        String targetUrl = frontUrl + "/login/callback";
 
         if (response.isCommitted()) {
             log.debug("Response has already been committed. Unable to redirect to " + targetUrl);


### PR DESCRIPTION
# 기능 구현 목록

1. 회의 종료 시, Meeting에 도메인 저장 로직 추가
2. meeting에 대한 여러 MeetingFile를 List 형식이 아닌, md + txt 두 개만 전송하는 로직으로 변경
3. Meeting 상세 조회 API 기능 수정 (회의 종료 시 리디렉션 URL 반환)
4. Front 도메인 Url 환경 변수 추가 및 swagger.yml 파일 수정
5. Meeting 종료 후 모델 서버 API 요청 로직 호출 시 isEnded = true로 하는 로직 구현